### PR TITLE
refactor(rules): rename git-branch rule to follow naming convention

### DIFF
--- a/.cursor/rules/utils/git-branch-agent.mdc
+++ b/.cursor/rules/utils/git-branch-agent.mdc
@@ -2,6 +2,7 @@
 
 ---
 description: This rule enforces standards and best practices for branch management operations including checkout, creation, and deletion. This rule should be followed when: 1. creating new branches, 2. switching between branches, 3. deleting branches, or 4. when the git aliases 'gco', 'gcb', or similar branch-related commands are used.
+globs: .git/HEAD
 alwaysApply: false
 ---
 


### PR DESCRIPTION
 - Rename git-branch.mdc to git-branch-agent.mdc to adhere to agent rule naming standards. Commit written by cursor agent