### PR TITLE
fix: ci: should update PR description on push to same branch

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -38,6 +38,9 @@ jobs:
 
   comment:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Install GitHub CLI

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -45,7 +45,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Install GitHub CLI
         run: sudo apt-get install gh
@@ -56,7 +55,7 @@ jobs:
           
 
           # Create new description with just commit messages
-          new_description="### Commit Messages:\n $commits"
+          new_description="### Changes: \n $commits"
           
           # Update the PR description
           gh pr edit ${{ github.event.pull_request.number }} --body "$new_description"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -51,14 +51,15 @@ jobs:
       - name: Add commit messages to PR description
         run: |
           # Get the commit messages from the PR
-          commits=$(gh pr view ${{ github.event.pull_request.number }} --json commits | jq -r '.commits[].message')
+          commits=$(gh pr view ${{ github.event.pull_request.number }} --json commits | jq -r '.commits[] | [.messageHeadline + .messageBody] | join("\n")' )
           
 
           # Create new description with just commit messages
-          new_description="### Changes: \n $commits"
+          new_description="## Changes <br/> <br/>"
           
           # Update the PR description
-          gh pr edit ${{ github.event.pull_request.number }} --body "$new_description"
+          gh pr edit ${{ github.event.pull_request.number }} --body "$new_description  $commits"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
           description: ${{ github.event.pull_request.body }}
+          CONTEXT: ${{ toJson(github.event.pull_request) }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -34,7 +34,7 @@ jobs:
           node-version: '20'
       - run: npm ci
       - name: Run tests
-        run: npm test
+        run: npm run test:ci
 
   comment:
     runs-on: ubuntu-latest
@@ -48,11 +48,21 @@ jobs:
       - name: Add commit messages to PR description
         run: |
           # Get the commit messages from the PR
-          commits=$(gh pr view ${{ github.event.pull_request.number }} --json commits -q '.commits[].message')
-          echo "COMMIT_MESSAGES=$commits" >> $GITHUB_ENV
-          description=$(gh pr view ${{ github.event.pull_request.number }} --json body -q '.body')
-          new_description="$description\n\n### Commit Messages:\n$COMMIT_MESSAGES"
+          commits=$(gh pr view ${{ github.event.pull_request.number }} --json commits | jq -r '.commits[].message | select(. != null)')
+          
+          # Check if we have any commit messages
+          if [ -z "$commits" ]; then
+            echo "No commit messages found, skipping PR description update"
+            exit 0
+          fi
+          
+          # Get current description
+          description=$(gh pr view ${{ github.event.pull_request.number }} --json body | jq -r '.body // empty')
+          
+          # Create new description with commit messages
+          new_description="${description:+$description\n\n}### Commit Messages:\n$commits"
+          
+          # Update the PR description
           gh pr edit ${{ github.event.pull_request.number }} --body "$new_description"
-
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -43,26 +43,23 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+
       - name: Install GitHub CLI
         run: sudo apt-get install gh
       - name: Add commit messages to PR description
         run: |
           # Get the commit messages from the PR
-          commits=$(gh pr view ${{ github.event.pull_request.number }} --json commits | jq -r '.commits[].message | select(. != null)')
+          commits=$(gh pr view ${{ github.event.pull_request.number }} --json commits | jq -r '.commits[].message')
           
-          # Check if we have any commit messages
-          if [ -z "$commits" ]; then
-            echo "No commit messages found, skipping PR description update"
-            exit 0
-          fi
-          
-          # Get current description
-          description=$(gh pr view ${{ github.event.pull_request.number }} --json body | jq -r '.body // empty')
-          
-          # Create new description with commit messages
-          new_description="${description:+$description\n\n}### Commit Messages:\n$commits"
+
+          # Create new description with just commit messages
+          new_description="### Commit Messages:\n $commits"
           
           # Update the PR description
           gh pr edit ${{ github.event.pull_request.number }} --body "$new_description"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          description: ${{ github.event.pull_request.body }}


### PR DESCRIPTION
## Changes <br/> <br/>  ci(workflows): add permissions for pull requests and contents in PR c……hecks configuration
ci(workflows): update test command in PR checks to use npm run test:ci
ci(workflows): set fetch-depth to 0 in PR checks for complete commit ……history
ci(workflows): update PR description to reflect changes instead of co……mmit messages
ci(workflows): modify commit message extraction in PR checks to inclu……de commit details