### PR TITLE
fix: remove unused 'flat' case from main function in cli.mjs

### DIFF
--- a/cli.mjs
+++ b/cli.mjs
@@ -114,7 +114,6 @@ async function main() {
             case 'output':
                 downloadFiles(values[key]?.toString() ?? '')
                 break;
-            case 'flat':
             default:
                 console.log(`~~~~ 📂 Flattening rules ~~~~`);
                 downloadFiles(path.join(process.cwd(), '.cursor'))


### PR DESCRIPTION
## Changes <br/> <br/>  fix: remove unused 'flat' case from main function in cli.mjs