### PR TITLE
feat: add Vue 3 and TypeScript standards rules for improved development practices

### DIFF
--- a/.cursor/rules/standards/vue3-typescript-auto.mdc
+++ b/.cursor/rules/standards/vue3-typescript-auto.mdc
@@ -1,0 +1,358 @@
+---
+description: Vue 3 with TypeScript Standards
+globs: *.vue,*.ts
+alwaysApply: false
+---
+
+# Vue 3 with TypeScript Standards
+
+Modern Vue 3 development with TypeScript, emphasizing type safety, Composition API, and performance.
+
+## Critical Rules
+
+- Use Composition API with `<script setup lang="ts">` syntax
+- Type all props, emits, reactive data, and composables explicitly
+- Use `defineModel()` for 2 way binding v-model and `defineSlots()` for slot typing
+- Follow PascalCase naming for components
+- Use proper provide/inject typing with injection keys
+- Type watchers explicitly and ensure proper cleanup
+- Optimize performance with computed properties and shallow reactivity
+
+<rule>
+name: vue3-typescript-essentials
+description: Core Vue 3 TypeScript standards for components and reactivity
+filters:
+  - type: file_extension
+    pattern: "\\.vue$"
+  - type: content
+    pattern: "export default \\{|defineProps|defineEmits|defineModel|defineSlots|ref\\(|reactive\\(|computed\\("
+actions:
+  - type: suggest
+    message: |
+      Follow Vue 3 TypeScript best practices:
+      
+      ✅ Use Composition API with proper typing:
+      <script setup lang="ts">
+      interface Props {
+        title: string
+        count?: number
+      }
+      interface Emits {
+        (e: 'update', value: number): void
+      }
+      interface Slots {
+        default(props: { item: string }): any
+        header(): any
+      }
+      
+      const props = defineProps<Props>()
+      const emit = defineEmits<Emits>()
+      const slots = defineSlots<Slots>()
+      const model = defineModel<string>()
+      const count = ref<number>(0)
+      const doubleCount = computed<number>(() => count.value * 2)
+      </script>
+      
+      ❌ Avoid Options API and untyped refs:
+      const props = defineProps(['title'])
+      const count = ref(0)
+examples:
+  - input: |
+      const props = defineProps(['title'])
+      const model = defineModel()
+      const count = ref(0)
+    output: |
+      interface Props {
+        title: string
+      }
+      const props = defineProps<Props>()
+      const model = defineModel<string>()
+      const count = ref<number>(0)
+metadata:
+  priority: high
+  version: 1.0
+</rule>
+
+<rule>
+name: vue3-models
+description: Proper typing for defineModel() and v-model bindings
+filters:
+  - type: file_extension
+    pattern: "\\.vue$"
+  - type: content
+    pattern: "defineModel|v-model"
+actions:
+  - type: suggest
+    message: |
+      ✅ Type v-model bindings properly:
+      
+      // Single v-model
+      const modelValue = defineModel<string>()
+      
+      // Named v-models
+      const isOpen = defineModel<boolean>('isOpen')
+      const selectedId = defineModel<number>('selectedId')
+      
+      // Optional v-model with default
+      const theme = defineModel<'light' | 'dark'>('theme', { default: 'light' })
+      
+      ❌ Avoid untyped models:
+      const modelValue = defineModel()
+      const isOpen = defineModel('isOpen')
+examples:
+  - input: |
+      const modelValue = defineModel()
+      const isVisible = defineModel('isVisible')
+    output: |
+      const modelValue = defineModel<string>()
+      const isVisible = defineModel<boolean>('isVisible')
+metadata:
+  priority: high
+  version: 1.0
+</rule>
+
+<rule>
+name: vue3-slots
+description: Proper typing for defineSlots() and slot definitions
+filters:
+  - type: file_extension
+    pattern: "\\.vue$"
+  - type: content
+    pattern: "defineSlots|<slot"
+actions:
+  - type: suggest
+    message: |
+      ✅ Type slots with proper interfaces:
+      
+      // Basic slots
+      interface Slots {
+        default(): any
+        header(): any
+        footer(): any
+      }
+      
+      // Slots with typed props
+      interface Slots {
+        default(props: { user: User; isActive: boolean }): any
+        item(props: { item: Product; index: number }): any
+        empty(): any
+      }
+      
+      const slots = defineSlots<Slots>()
+      
+      ❌ Avoid untyped slots:
+      const slots = defineSlots()
+examples:
+  - input: |
+      const slots = defineSlots()
+    output: |
+      interface Slots {
+        default(props: { item: any }): any
+      }
+      const slots = defineSlots<Slots>()
+metadata:
+  priority: high
+  version: 1.0
+</rule>
+
+<rule>
+name: vue3-composables-naming
+description: Standards for composables and component naming with TypeScript
+filters:
+  - type: file_extension
+    pattern: "\\.(vue|ts)$"
+  - type: content
+    pattern: "use[A-Z]\\w+|<template>"
+actions:
+  - type: suggest
+    message: |
+      ✅ Composable structure:
+      export interface UseCounterReturn {
+        count: Ref<number>
+        increment: () => void
+      }
+      
+      export function useCounter(initial = 0): UseCounterReturn {
+        const count = ref<number>(initial)
+        const increment = (): void => { count.value++ }
+        return { count, increment }
+      }
+      
+      ✅ Component naming: UserProfile.vue, TheHeader.vue
+      ❌ Avoid: userProfile.vue, user_profile.vue
+examples:
+  - input: |
+      export function useCounter() {
+        const count = ref(0)
+        return { count }
+      }
+    output: |
+      export interface UseCounterReturn {
+        count: Ref<number>
+      }
+      export function useCounter(): UseCounterReturn {
+        const count = ref<number>(0)
+        return { count }
+      }
+metadata:
+  priority: medium
+  version: 1.0
+</rule>
+
+<rule>
+name: vue3-watchers
+description: Best practices for watch and watchEffect with TypeScript
+filters:
+  - type: file_extension
+    pattern: "\\.(vue|ts)$"
+  - type: content
+    pattern: "watch\\(|watchEffect\\(|watchPostEffect|watchSyncEffect"
+actions:
+  - type: suggest
+    message: |
+      ✅ Use watchers properly with TypeScript:
+      
+      // watch() for specific reactive sources
+      watch(
+        () => user.value?.id,
+        (newId: number | undefined, oldId: number | undefined) => {
+          if (newId) {
+            fetchUserData(newId)
+          }
+        },
+        { immediate: true }
+      )
+      
+      // watch multiple sources
+      watch(
+        [() => props.userId, searchQuery],
+        async ([userId, query]: [number | undefined, string]) => {
+          if (userId && query) {
+            await searchUserData(userId, query)
+          }
+        }
+      )
+      
+      // watchEffect for side effects
+      watchEffect(() => {
+        if (user.value && isLoggedIn.value) {
+          analytics.track('user_active', { userId: user.value.id })
+        }
+      })
+      
+      // Cleanup watchers
+      const stopWatcher = watch(data, callback)
+      onUnmounted(() => stopWatcher())
+      
+      ❌ Avoid untyped watchers and missing cleanup:
+      watch(user, (newVal, oldVal) => { ... })
+      watchEffect(() => { ... }) // without cleanup consideration
+examples:
+  - input: |
+      watch(user, (newVal, oldVal) => {
+        console.log('User changed')
+      })
+    output: |
+      watch(
+        user,
+        (newUser: User | null, oldUser: User | null) => {
+          if (newUser) {
+            console.log('User changed:', newUser.name)
+          }
+        }
+      )
+metadata:
+  priority: medium
+  version: 1.0
+</rule>
+
+<rule>
+name: vue3-advanced-patterns
+description: Type-safe provide/inject and performance optimization
+filters:
+  - type: file_extension
+    pattern: "\\.(vue|ts)$"
+  - type: content
+    pattern: "provide\\(|inject\\(|shallowRef|defineAsyncComponent"
+actions:
+  - type: suggest
+    message: |
+      ✅ Type-safe dependency injection:
+      // types/keys.ts
+      export const UserKey: InjectionKey<Ref<User | null>> = Symbol('user')
+      
+      // Usage
+      provide(UserKey, currentUser)
+      const user = inject(UserKey)
+      
+      ✅ Performance patterns:
+      const largeList = shallowRef<Item[]>([])
+      const filtered = computed(() => items.value.filter(item => item.active))
+      const AsyncComp = defineAsyncComponent(() => import('./Heavy.vue'))
+examples:
+  - input: |
+      provide('user', currentUser)
+      const user = inject('user')
+    output: |
+      export const UserKey: InjectionKey<Ref<User | null>> = Symbol('user')
+      provide(UserKey, currentUser)
+      const user = inject(UserKey)
+metadata:
+  priority: high
+  version: 1.0
+</rule>
+
+## File Structure
+
+```
+src/
+├── components/         # Reusable components
+├── composables/        # Vue composables
+├── layouts/            # Vue layouts
+├── stores/             # Vue stores
+├── utils/              # Vue utils
+├── types/              # TypeScript definitions
+└── pages/              # Page components
+
+```
+
+### Import Order
+
+```typescript
+// 1. Vue core
+import { ref, computed } from "vue";
+// 2. Vue ecosystem
+import { useRouter } from "vue-router";
+// 3. Third-party
+import axios from "axios";
+// 4. Local
+import UserCard from "@/components/UserCard.vue";
+```
+
+tests:
+
+- input: |
+    <script>
+    export default {
+      props: ['user'],
+      model: { prop: 'value', event: 'input' },
+      data() { return { count: 0 } }
+    }
+    </script>
+  output: |
+    <script setup lang="ts">
+    interface Props { user: User }
+    interface Slots {
+      default(): any
+    }
+    const props = defineProps<Props>()
+    const slots = defineSlots<Slots>()
+    const modelValue = defineModel<string>()
+    const count = ref<number>(0)
+    </script>
+- input: "const modelValue = defineModel()"
+  output: "const modelValue = defineModel<string>()"
+- input: "provide('theme', 'dark')"
+  output: |
+  export const ThemeKey: InjectionKey<string> = Symbol('theme')
+  provide(ThemeKey, 'dark')

--- a/.cursor/rules/test/vue-test-utils-auto.mdc
+++ b/.cursor/rules/test/vue-test-utils-auto.mdc
@@ -1,0 +1,274 @@
+---
+description: @vue/test-utils Standards for Vue 3 components and Vitest
+globs: *.test.{ts,js},*.spec.{ts,js},__tests__/**/*
+alwaysApply: false
+---
+
+# Vue Test Utils Standards
+
+Comprehensive testing standards for Vue 3 components using @vue/test-utils with TypeScript support.
+
+## Critical Rules
+
+- Use @vue/test-utils with TypeScript for type-safe component testing
+- Test component props, emits, slots, and user interactions thoroughly
+- Mock composables and external dependencies appropriately
+- Use data-testid attributes for reliable element selection
+- Test component behavior, not implementation details
+- Provide proper TypeScript types for test props and mocks
+
+<rule>
+name: vue-test-utils-typescript
+description: Standards for Vue component testing with @vue/test-utils and TypeScript
+filters:
+  - type: file_extension
+    pattern: "\\.(test|spec)\\.(ts|js)$"
+  - type: content
+    pattern: "mount|shallowMount|@vue/test-utils"
+actions:
+  - type: suggest
+    message: |
+      Use @vue/test-utils with proper TypeScript typing:
+      
+      ✅ Good component test structure:
+      import { mount, VueWrapper } from "@vue/test-utils"
+      import { describe, it, expect, vi, beforeEach } from "vitest"
+      import UserProfile from "@/components/UserProfile.vue"
+      import type { User } from "@/types/user"
+      
+      describe("UserProfile.vue", () => {
+        let wrapper: VueWrapper<any>
+        const mockUser: User = {
+          id: 1,
+          name: "John Doe",
+          email: "john@example.com"
+        }
+        
+        beforeEach(() => {
+          wrapper = mount(UserProfile, {
+            props: { user: mockUser }
+          })
+        })
+        
+        it("renders user information correctly", () => {
+          expect(wrapper.find('[data-testid="user-name"]').text()).toBe("John Doe")
+          expect(wrapper.find('[data-testid="user-email"]').text()).toBe("john@example.com")
+        })
+        
+        it("emits update event when edited", async () => {
+          await wrapper.find('[data-testid="edit-button"]').trigger("click")
+          expect(wrapper.emitted("update")).toBeTruthy()
+        })
+      })
+      
+      ❌ Avoid untyped tests and unclear selectors:
+      const wrapper = mount(UserProfile)
+      expect(wrapper.find(".user-name").text()).toBe("John")
+examples:
+  - input: |
+      import { mount } from "@vue/test-utils"
+      const wrapper = mount(UserProfile)
+      expect(wrapper.find(".user-name").text()).toBe("John")
+    output: |
+      import { mount, VueWrapper } from "@vue/test-utils"
+      import type { User } from "@/types/user"
+      
+      const mockUser: User = { id: 1, name: "John Doe", email: "john@example.com" }
+      const wrapper: VueWrapper<any> = mount(UserProfile, {
+        props: { user: mockUser }
+      })
+      expect(wrapper.find('[data-testid="user-name"]').text()).toBe("John Doe")
+metadata:
+  priority: high
+  version: 1.0
+</rule>
+
+<rule>
+name: vue-test-composables-mocking
+description: Standards for mocking composables and external dependencies
+filters:
+  - type: file_extension
+    pattern: "\\.(test|spec)\\.(ts|js)$"
+  - type: content
+    pattern: "vi\\.mock|mockReturnValue|use[A-Z]\\w+"
+actions:
+  - type: suggest
+    message: |
+      Mock composables and dependencies properly:
+      
+      ✅ Good composable mocking:
+      import { vi } from "vitest"
+      import type { UseUserReturn } from "@/composables/useUser"
+      
+      // Mock the composable
+      vi.mock("@/composables/useUser", () => ({
+        useUser: vi.fn((): UseUserReturn => ({
+          user: ref({ id: 1, name: "Test User" }),
+          loading: ref(false),
+          fetchUser: vi.fn(),
+          updateUser: vi.fn()
+        }))
+      }))
+      
+      // Mock external libraries
+      vi.mock("vue-router", () => ({
+        useRouter: () => ({
+          push: vi.fn(),
+          replace: vi.fn()
+        })
+      }))
+      
+      ❌ Avoid untyped mocks:
+      vi.mock("@/composables/useUser")
+      const mockUseUser = useUser as any
+examples:
+  - input: |
+      vi.mock("@/composables/useUser")
+      const mockRouter = { push: vi.fn() }
+    output: |
+      import type { UseUserReturn } from "@/composables/useUser"
+      
+      vi.mock("@/composables/useUser", () => ({
+        useUser: vi.fn((): UseUserReturn => ({
+          user: ref(null),
+          loading: ref(false),
+          fetchUser: vi.fn()
+        }))
+      }))
+      
+      vi.mock("vue-router", () => ({
+        useRouter: () => ({ push: vi.fn() })
+      }))
+metadata:
+  priority: high
+  version: 1.0
+</rule>
+
+<rule>
+name: vue-test-slots-events
+description: Testing Vue component slots and events properly
+filters:
+  - type: file_extension
+    pattern: "\\.(test|spec)\\.(ts|js)$"
+  - type: content
+    pattern: "slots|emitted|trigger"
+actions:
+  - type: suggest
+    message: |
+      Test slots and events with proper typing:
+      
+      ✅ Good slot and event testing:
+      // Testing slots
+      const wrapper = mount(DialogComponent, {
+        slots: {
+          default: '<p data-testid="slot-content">Custom content</p>',
+          header: '<h2 data-testid="header">Custom Header</h2>'
+        }
+      })
+      expect(wrapper.find('[data-testid="slot-content"]').exists()).toBe(true)
+      
+      // Testing events with payload
+      await wrapper.find('[data-testid="submit-button"]').trigger("click")
+      const updateEvents = wrapper.emitted("update") as Array<[string]>
+      expect(updateEvents).toHaveLength(1)
+      expect(updateEvents[0][0]).toBe("expected-payload")
+      
+      // Testing v-model
+      const input = wrapper.find('input[data-testid="name-input"]')
+      await input.setValue("New Value")
+      const modelEvents = wrapper.emitted("update:modelValue") as Array<[string]>
+      expect(modelEvents[0][0]).toBe("New Value")
+examples:
+  - input: |
+      await wrapper.find("button").trigger("click")
+      expect(wrapper.emitted("update")).toBeTruthy()
+    output: |
+      await wrapper.find('[data-testid="submit-button"]').trigger("click")
+      const updateEvents = wrapper.emitted("update") as Array<[any]>
+      expect(updateEvents).toHaveLength(1)
+metadata:
+  priority: medium
+  version: 1.0
+</rule>
+
+## Testing Patterns
+
+### Component Props Testing
+
+```typescript
+interface TestProps {
+  user: User;
+  isVisible?: boolean;
+}
+
+const defaultProps: TestProps = {
+  user: { id: 1, name: "Test User", email: "test@example.com" },
+  isVisible: true,
+};
+
+const wrapper = mount(Component, { props: defaultProps });
+```
+
+### Async Testing
+
+```typescript
+it("handles async operations", async () => {
+  const wrapper = mount(AsyncComponent);
+
+  // Wait for async operation
+  await flushPromises();
+
+  // Or wait for next tick
+  await wrapper.vm.$nextTick();
+
+  expect(wrapper.find('[data-testid="result"]').text()).toBe("Loaded");
+});
+```
+
+### Global Plugins Testing
+
+```typescript
+const wrapper = mount(Component, {
+  global: {
+    plugins: [router, pinia],
+    provide: {
+      [UserKey]: mockUser,
+    },
+    stubs: {
+      "router-link": true,
+      "heavy-component": true,
+    },
+  },
+});
+```
+
+tests:
+
+- input: |
+  const wrapper = mount(UserCard)
+  expect(wrapper.find(".name").text()).toBe("John")
+  output: |
+  const mockUser: User = { id: 1, name: "John Doe", email: "john@example.com" }
+  const wrapper: VueWrapper<any> = mount(UserCard, {
+  props: { user: mockUser }
+  })
+  expect(wrapper.find('[data-testid="user-name"]').text()).toBe("John Doe")
+- input: |
+  vi.mock("@/composables/useAuth")
+  const mockAuth = useAuth as any
+  output: |
+  import type { UseAuthReturn } from "@/composables/useAuth"
+  vi.mock("@/composables/useAuth", () => ({
+  useAuth: vi.fn((): UseAuthReturn => ({
+  user: ref(null),
+  isAuthenticated: ref(false),
+  login: vi.fn()
+  }))
+  }))
+- input: |
+  await wrapper.find("button").trigger("click")
+  expect(wrapper.emitted("save")).toBeTruthy()
+  output: |
+  await wrapper.find('[data-testid="save-button"]').trigger("click")
+  const saveEvents = wrapper.emitted("save") as Array<[any]>
+  expect(saveEvents).toHaveLength(1)


### PR DESCRIPTION
This pull request introduces two new standards files for Vue 3 development and testing. The `.cursor/rules/standards/vue3-typescript-auto.mdc` file defines best practices for Vue 3 with TypeScript, focusing on type safety, Composition API, and performance. The `.cursor/rules/test/vue-test-utils-auto.mdc` file provides comprehensive testing standards for Vue 3 components using @vue/test-utils and Vitest, emphasizing type-safe tests and proper mocking. These additions will help enforce consistent, modern, and robust patterns across both application and test code.

Vue 3 TypeScript standards:

* Added `.cursor/rules/standards/vue3-typescript-auto.mdc` to define critical rules for using the Composition API, explicit typing of props/emits/composables, slot typing, PascalCase component naming, type-safe provide/inject, watcher cleanup, and performance optimization.
* Included example code, file structure guidelines, and import order recommendations to help maintain consistency and readability.

Vue 3 component testing standards:

* Added `.cursor/rules/test/vue-test-utils-auto.mdc` with rules for using @vue/test-utils and Vitest, covering type-safe mounting, thorough props/emits/slots/user interaction testing, composable and dependency mocking, and reliable selectors via data-testid.
* Provided patterns for async testing, global plugin setup, and slot/event assertions, along with example transformations for common test scenarios.