### PR TITLE
fix: default output dir should be cwd

### DIFF
--- a/cli/commands.mjs
+++ b/cli/commands.mjs
@@ -1,6 +1,5 @@
 'use strict'
 import * as fs from 'node:fs/promises';
-import { homedir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { styleText } from 'node:util';
@@ -13,7 +12,7 @@ import { validateDirname } from './utils/validate-dirname.mjs';
 export const __dirname = dirname(fileURLToPath(import.meta.url));
 export const packageJsonPath = resolve(__dirname, '..', 'package.json');
 export const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
-const defaultOutput = resolve(homedir(), 'Downloads', '.cursor');
+const defaultOutput = process.cwd();
 
 /** @returns {void} */
 export const help = () => {

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -68,11 +68,11 @@ async function main() {
                 await interactiveMode(values);
                 process.exit(0);
             case 'output':
-                const outputDir = values[key]?.toString() ?? defaultCursorPath;
+                const outputDir = values[key]?.toString() ?? process.cwd();
                 await output(outputDir);
                 break;
             case 'flat':
-                const cursorRulesPath = process.env.npm_config_prefix?.toString() ?? `${defaultCursorPath}/rules`;
+                const cursorRulesPath = process.cwd();
                 await downloadFiles(cursorRulesPath);
                 break;
         }

--- a/cli/utils/download-files.mjs
+++ b/cli/utils/download-files.mjs
@@ -75,12 +75,12 @@ export const downloadSelectedFiles = async (folderName, selectedRules) => {
     try {
         // Create output directory structure
         await mkdir(outputDir, { recursive: true });
-        await mkdir(join(outputDir, 'rules'), { recursive: true });
+        await mkdir(join(outputDir, '.cursor'), { recursive: true });
 
         // Copy selected rules
         for (const rule of selectedRules) {
             const sourcePath = join(sourceRulesBasePath, rule.path);
-            const destPath = join(outputDir, 'rules', rule.path);
+            const destPath = join(outputDir, '.cursor', 'rules', rule.path);
             const destDir = dirname(destPath);
 
             // Ensure destination directory exists


### PR DESCRIPTION
fix:  default output dir should be cwd- Changed the default output directory to the current working directory instead of a predefined cursor path.
- Updated the cursor rules path to use the current working directory for improved flexibility in file downloads.
refactor: Change default output directory to current working directory
fix: update output directory for downloadSelected Rules from 'rules' ……to '.cursor/rules'