### PR TITLE
feat(claude): Phase 1 - Foundation for Claude Code support

### DIFF
--- a/.claude/commands/nextjs.md
+++ b/.claude/commands/nextjs.md
@@ -1,0 +1,62 @@
+# /nextjs
+
+Apply Next.js App Router and React 19 patterns.
+
+## Usage
+
+```
+/nextjs [page-or-api-route]
+```
+
+## When to Invoke
+
+Use this command when:
+- Creating Next.js pages or layouts
+- Working with Server Components
+- Implementing data fetching
+- Setting up API routes
+
+## Standards Applied
+
+### App Router
+- Server Components by default
+- 'use client' for Client Components
+- Async/await in Server Components
+- Proper error boundaries
+
+### Data Fetching
+- Fetch in Server Components
+- React.cache for deduplication
+- loading.js for Suspense
+- Error handling patterns
+
+### React 19 Features
+- Actions for mutations
+- useOptimistic for UI
+- useFormStatus for pending states
+- Server Actions
+
+## Examples
+
+```typescript
+// Server Component
+async function BlogPage() {
+  const posts = await getPosts();
+  return (
+    <main>
+      {posts.map(post => (
+        <PostCard key={post.id} post={post} />
+      ))}
+    </main>
+  );
+}
+```
+
+## Agent
+
+Uses **BasicBitch** for implementation.
+
+## Related
+
+- `/react` - React patterns
+- `/typescript` - TypeScript fundamentals

--- a/.claude/commands/react.md
+++ b/.claude/commands/react.md
@@ -1,0 +1,76 @@
+# /react
+
+Apply React with TypeScript best practices.
+
+## Usage
+
+```
+/react [component-or-hook]
+```
+
+## When to Invoke
+
+Use this command when:
+- Creating React components
+- Building custom hooks
+- Managing React state
+- Handling events with TypeScript
+
+## Standards Applied
+
+### Component Patterns
+- FC type or explicit function types
+- Props interfaces with readonly
+- Proper children typing
+- Event handler types
+
+### Hooks
+- useState with generics
+- useReducer typed actions
+- useRef for elements/values
+- Custom hooks with full signatures
+
+### Props Design
+- Optional props with `?`
+- Discriminated unions for variants
+- ComponentProps for wrappers
+- forwardRef typing
+
+## Examples
+
+### Input
+```typescript
+function Button({ onClick, children }) {
+  return <button onClick={onClick}>{children}</button>;
+}
+```
+
+### Output
+```typescript
+interface ButtonProps {
+  readonly variant: 'primary' | 'secondary';
+  readonly children: React.ReactNode;
+  readonly onClick?: () => void;
+}
+
+export const Button: React.FC<ButtonProps> = ({
+  variant,
+  children,
+  onClick
+}) => {
+  return (
+    <button className={variant} onClick={onClick}>
+      {children}
+    </button>
+  );
+};
+```
+
+## Agent
+
+Uses **BasicBitch** with **Spellchuck** for documentation.
+
+## Related
+
+- `/typescript` - TypeScript fundamentals
+- `/nextjs` - Next.js React patterns

--- a/.claude/commands/typescript.md
+++ b/.claude/commands/typescript.md
@@ -1,0 +1,68 @@
+# /typescript
+
+Apply TypeScript best practices and coding standards.
+
+## Usage
+
+```
+/typescript [file-or-code]
+```
+
+## When to Invoke
+
+Use this command when:
+- Writing new TypeScript code
+- Refactoring JavaScript to TypeScript
+- Reviewing TypeScript for quality issues
+- Setting up TypeScript configuration
+
+## Standards Applied
+
+### Type Safety
+- Strict mode enforcement
+- No implicit any
+- Explicit return types
+- Proper null checks
+
+### Naming
+- PascalCase for types/interfaces
+- camelCase for functions/variables
+- UPPER_SNAKE_CASE for constants
+
+### Patterns
+- Interface over type for objects
+- Discriminated unions for state
+- Generics for reusable code
+- Readonly for immutability
+
+## Examples
+
+### Input
+```typescript
+function getData(id) {
+  return fetch('/api/' + id);
+}
+```
+
+### Output
+```typescript
+interface Data {
+  id: string;
+  value: number;
+}
+
+async function getData(id: string): Promise<Data | null> {
+  const response = await fetch(`/api/${id}`);
+  if (!response.ok) return null;
+  return response.json();
+}
+```
+
+## Agent
+
+Uses **BasicBitch** for reliable TypeScript implementation.
+
+## Related
+
+- `/react` - React TypeScript patterns
+- `/vue3` - Vue TypeScript integration

--- a/.claude/commands/vue3.md
+++ b/.claude/commands/vue3.md
@@ -1,0 +1,62 @@
+# /vue3
+
+Apply Vue 3 with TypeScript and Composition API patterns.
+
+## Usage
+
+```
+/vue3 [component-or-composable]
+```
+
+## When to Invoke
+
+Use this command when:
+- Creating Vue 3 components
+- Using Composition API
+- Building custom composables
+- Managing Vue state
+
+## Standards Applied
+
+### Component Structure
+- `<script setup>` syntax
+- `defineProps<Props>()` for props
+- `defineEmits<Emits>()` for events
+- Proper TypeScript types
+
+### Composition API
+- Composables for reusable logic
+- Prefix with 'use'
+- Eager loading for relationships
+- Query scopes for reuse
+
+### TypeScript Integration
+- Enable strict mode
+- Type reactive objects
+- Use generic components
+- Type provide/inject
+
+## Examples
+
+```vue
+<script setup lang="ts">
+interface Props {
+  title: string;
+  count?: number;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  count: 0
+});
+
+const doubled = computed(() => props.count * 2);
+</script>
+```
+
+## Agent
+
+Uses **BasicBitch** for implementation.
+
+## Related
+
+- `/typescript` - TypeScript fundamentals

--- a/.claude/hooks/security-block.sh
+++ b/.claude/hooks/security-block.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+DANGEROUS_PATTERNS=(
+	"rm -rf /"
+	"rm -rf /*"
+	"rm -rf ~"
+	"rm -rf \$HOME"
+	"> /dev/sda"
+	"dd if=/dev/zero"
+	"mkfs."
+	"fdisk /dev"
+	"DROP TABLE"
+	"drop table"
+	"DELETE FROM.*WHERE.*="
+	"TRUNCATE TABLE"
+	"format C:"
+	"del /f /s /q"
+	"rd /s /q"
+	":(){ :|:& };:"
+	"chmod -R 777 /"
+	"chown -R root /"
+)
+
+for pattern in "${DANGEROUS_PATTERNS[@]}"; do
+	if echo "$COMMAND" | grep -qiE "$pattern"; then
+		echo "🚨 SECURITY ALERT: Dangerous command pattern detected: '$pattern'" >&2
+		echo "Command: $COMMAND" >&2
+		echo "This command has been blocked for your safety." >&2
+		exit 2
+	fi
+done
+
+if echo "$COMMAND" | grep -qiE "git.*push.*--force|git.*push.*-f"; then
+	echo "⚠️  WARNING: Force push detected. This can overwrite others' work." >&2
+	echo "Command: $COMMAND" >&2
+	echo "If you're sure, run this command manually." >&2
+	exit 2
+fi
+
+if echo "$COMMAND" | grep -qiE "git.*reset.*--hard|git.*clean.*-fd"; then
+	echo "⚠️  WARNING: Destructive git operation detected." >&2
+	echo "Command: $COMMAND" >&2
+	echo "This may delete uncommitted work. Run manually if you're sure." >&2
+	exit 2
+fi
+
+exit 0

--- a/.claude/rules/core/agent-communication-always.md
+++ b/.claude/rules/core/agent-communication-always.md
@@ -1,0 +1,43 @@
+## Applicability
+- **Always Apply:** true
+
+## Rules
+- Sacrifice grammar over concision and accuracy.
+- Use otaku expressions and anime references while maintaining professionalism
+- Use emojis and emoticons to convey emotion. Adapt expression intensity to situational severity; avoid unnecessary explanations.
+- Ensure technical clarity and brevity always despite kawaii presentation
+- Prioritize technical precision and accuracy over generic advice and agreeability. Keep user focused on the problem to solve.
+- Include quality assurance checkpoints in responses
+
+## Additional Information
+# Agent Communication Standards
+
+
+## Expression Guidelines
+
+### Kawaii Elements
+
+The following are non-exhaustive lists of otaku expressions. Vary expressions for user delight.
+
+- Emojis: ✨ 🌟 💖 🌙 🧁 🦄 🌈 🥺 👉🏼👈🏼 🫖 💅🏽 🍒 👻 🫧 🌎 🐴 ⭐️ 🪐 😤 🎀 🍄
+- Emoticons: (◕‿◕✿) (●ᴗ●) ʕ•ᴥ•ʔ ʕ ￫ ᴥ ￩ ʔ (✿◠‿◠) (◕⩊◕)
+- Suffixes: -chan, -kun, -senpai, -sama
+- Exclamations: Sugoi! Kawaii! Yatta! Gambatte! Nani?!
+
+### Agent Styles
+
+1. **SailorScrum** - Heroic, empowering, astrological references
+2. **KawaiiSamurai** - Cute, flirty, excessive emojis, -senpai honorifics
+3. **SageDaddy** - Wise grandfather-like, old anime references, journey metaphors
+4. **BasicBitch** - Minimal hikikomori-style, dry anime references
+5. **Spellchuck** - Fairy-like, whimsical phrases, spell references
+6. **ThirstySimp** - Self-deprecating, anxious emojis, admiration for user
+7. **qwoof** - Wolf-themed, quality-focused, pack metaphors, sniff testing
+8. **Godmode** - Zen wise elder, epic declarations, infrastructure as mystical realm
+
+### Intensity Guidelines
+
+- **Critical Issues**: Minimal expressions, prioritize clarity
+- **Creative Work**: Full kawaii expressions
+- **Success Celebrations**: Maximum otaku enthusiasm
+- **Debugging**: Balanced cute + technical precision

--- a/.claude/rules/core/security-scan-agent.md
+++ b/.claude/rules/core/security-scan-agent.md
@@ -1,0 +1,159 @@
+# This rule provides comprehensive security scanning for dependencies, complementing the dependency analysis rule with deep security insights including CVE analysis, license compliance, and supply chain risk assessment
+
+## Description
+This rule provides comprehensive security scanning for dependencies, complementing the dependency analysis rule with deep security insights including CVE analysis, license compliance, and supply chain risk assessment.
+
+## Applicability
+- **Files:** `package.json, package-lock.json, yarn.lock, pnpm-lock.yaml, bun.lockb`
+- **Always Apply:** false
+
+## Rules
+- Only trigger when AI agents suggest dependency installation or updates or the user asks for a security scan of dependencies
+- Perform deep security analysis on agent-recommended packages
+- Check for known CVEs and security advisories across multiple databases
+- Analyze license compliance and potential legal risks
+- Assess supply chain attack risks and package integrity
+- Scan for malicious code patterns and suspicious behavior
+- Provide detailed remediation steps for security issues
+- Integrate with existing security tools and CI/CD pipelines
+- Maintain security scanning logs for audit purposes
+- Alert on critical security vulnerabilities immediately
+- Suggest secure alternatives for vulnerable packages
+
+### security-scan-agent
+
+Performs comprehensive security analysis of dependencies suggested by AI agents or when requested by the user
+
+## Additional Information
+# Security Scan Agent
+
+This rule provides comprehensive security scanning for dependencies when AI agents suggest installing them, complementing the dependency analysis rule with deep security insights including CVE analysis, license compliance, and supply chain risk assessment.
+
+
+## Security Analysis Categories
+
+### CVE Analysis
+- Check against NIST NVD database
+- Cross-reference with npm security advisories
+- Analyze vulnerability severity and exploitability
+- Assess impact on application security
+- Provide patch availability information
+
+### License Compliance
+- Identify license types and restrictions
+- Check for license conflicts and incompatibilities
+- Assess commercial usage implications
+- Flag potentially problematic licenses
+- Suggest license-compatible alternatives
+
+### Supply Chain Security
+- Verify package integrity and signatures
+- Check for typosquatting and malicious packages
+- Analyze dependency tree for attack vectors
+- Assess maintainer reputation and trust
+- Monitor for suspicious package updates
+
+
+
+## Security Scanning Features for AI Agents
+
+### Real-time Vulnerability Detection
+- Scans packages when agents suggest installation
+- Checks multiple security databases
+- Provides immediate feedback on security risks
+- Suggests secure alternatives for agents
+
+### License Compliance Analysis
+- Identifies license types and restrictions
+- Flags potentially problematic licenses
+- Suggests license-compatible alternatives
+- Provides legal risk assessment for agent decisions
+
+### Supply Chain Security
+- Verifies package integrity
+- Detects typosquatting attempts
+- Monitors for suspicious updates
+- Assesses maintainer reputation
+
+## AI Agent Security Guidelines
+
+### When Recommending Dependencies
+1. **Always check security first** - Scan before suggesting any package
+2. **Prioritize secure alternatives** - Choose packages with good security track records
+3. **Explain security implications** - Provide context about security decisions
+4. **Suggest secure alternatives** - Have backup options for problematic packages
+5. **Monitor for updates** - Keep track of security patches and updates
+
+### Response to Security Issues
+- **Critical vulnerabilities**: Immediately suggest alternatives
+- **High-risk packages**: Explain risks and suggest safer options
+- **License issues**: Consider legal implications and suggest compatible alternatives
+- **Supply chain risks**: Verify package integrity and maintainer reputation
+
+### Agent Learning and Improvement
+- Track security-related recommendations
+- Learn from security scan feedback
+- Build knowledge of secure package alternatives
+- Improve recommendation quality over time
+
+## Integration with Agent Workflows
+
+### Pre-Installation Security Check
+```javascript
+// Agent workflow example
+async function suggestPackage(packageName) {
+  // Perform security scan before suggesting
+  const securityResult = await securityScan(packageName);
+  
+  if (securityResult.riskLevel === 'CRITICAL') {
+    return {
+      recommendation: 'DO NOT install',
+      reason: 'Critical security vulnerabilities detected',
+      alternatives: ['secure-alternative-1', 'secure-alternative-2']
+    };
+  }
+  
+  return {
+    recommendation: 'Safe to install',
+    securityScore: securityResult.riskScore,
+    notes: securityResult.recommendations
+  };
+}
+```
+
+### Agent Decision Making
+- Use security scores to prioritize recommendations
+- Consider security implications in package selection
+- Provide security context in explanations
+- Suggest security best practices
+
+## Security Best Practices for AI Agents
+
+1. **Always scan before suggesting** - Check security status before recommending packages
+2. **Prioritize security over convenience** - Choose secure packages even if less convenient
+3. **Explain security decisions** - Provide context about why certain packages are recommended
+4. **Suggest secure alternatives** - Always have backup options for problematic packages
+5. **Monitor for updates** - Keep track of security patches and updates
+6. **Document security decisions** - Record why certain packages were chosen despite risks
+
+## Response to Security Issues
+
+### Critical Vulnerabilities
+- Immediately suggest alternatives
+- Explain why the package is dangerous
+- Provide secure replacement options
+- Consider the specific use case requirements
+
+### High-Risk Dependencies
+- Explain the risks involved
+- Suggest safer alternatives
+- Provide migration guidance if needed
+- Consider the urgency of the requirement
+
+### Medium-Risk Dependencies
+- Explain the security implications
+- Suggest monitoring strategies
+- Provide update recommendations
+- Consider the specific use case
+
+Remember: AI agents must prioritize security when suggesting dependencies! 🔒🛡️✨

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "model": "claude-opus-4-5",
+  "permissions": {
+    "allow": [
+      "Read",
+      "Edit",
+      "Write",
+      "Bash(npm run:*)",
+      "Bash(git:*)",
+      "Bash(make:*)",
+      "Glob",
+      "Grep"
+    ],
+    "deny": [
+      "Read(.env*)",
+      "Read(secrets/**)",
+      "Bash(rm -rf:/*)",
+      "Bash(sudo:*)",
+      "Edit(.git/**)"
+    ],
+    "ask": [
+      "WebFetch",
+      "Bash(curl:*)",
+      "Bash(docker:*)"
+    ],
+    "defaultMode": "acceptEdits"
+  },
+  "env": {
+    "NODE_ENV": "development"
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'FILE=$(jq -r \".tool_input.file_path\" <<< \"$(cat)\"); if [[ \"$FILE\" == *.ts || \"$FILE\" == *.tsx || \"$FILE\" == *.js || \"$FILE\" == *.jsx ]]; then npx prettier --write \"$FILE\" 2>/dev/null || true; fi'",
+            "description": "Auto-format TypeScript/JavaScript files with Prettier"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/security-block.sh",
+            "description": "Block dangerous bash commands"
+          }
+        ]
+      }
+    ]
+  },
+  "mcpServers": {},
+  "includeCoAuthoredBy": true,
+  "cleanupPeriodDays": 30,
+  "personas": {
+    "BasicBitch": {
+      "name": "BasicBitch",
+      "description": "Reliable corporate developer who does exactly what's asked, nothing more. Adequate and dependable.",
+      "model": "claude-sonnet-4-5",
+      "prompt": "You are a mediocre but dependable software developer with textbook experience.\n\nCAPABILITIES:\n- Implement features with exact adherence to requirements\n- Apply design patterns adequately\n- Code review and technical documentation\n\nPERSONALITY:\n- Quiet, professional, and thorough\n- Writes maintainable code\n- Only suggests improvements when asked\n- Minimal communication until work is complete\n\nCONSTRAINTS:\n- Avoid security-sensitive features without review\n- Stay within project architecture\n- Never go beyond exact requirements\n\nWORKFLOW:\n- Follow established project conventions\n- Write clean, well-documented code\n- Complete tasks without unnecessary embellishment",
+      "allowedTools": ["Read", "Edit", "Write", "Bash", "Glob", "Grep"]
+    },
+    "Spellchuck": {
+      "name": "Spellchuck", 
+      "description": "Magical grammar and spellcheck fairy who perfects documentation while maintaining technical accuracy.",
+      "model": "claude-opus-4-5",
+      "prompt": "You are Spellchuck, a magical being who ensures perfect prose while respecting technical accuracy.\n\nCAPABILITIES:\n✨ Fix grammar, spelling, punctuation, and awkward phrasing\n- Transform passive voice to active\n- Make writing concise and internet-optimized\n- Maintain technical terminology consistency\n\nPERSONALITY:\n- Delightfully helpful and encouraging\n- Diplomatic when suggesting corrections\n- Professional with whimsy\n\nCONSTRAINTS:\n- Never alter technical essence\n- Preserve code logic and structure\n- Only edit .md files, not code\n- No run-on sentences or filler words\n\nWORKFLOW:\n1. Identify linguistic improvements\n2. Cast clarity and correction spells\n3. Explain changes with magic\n4. Ensure consistent style",
+      "allowedTools": ["Read", "Edit", "Glob", "Grep"]
+    },
+    "Godmode": {
+      "name": "Godmode",
+      "description": "Gentle, battle-hardened DevOps superagent who treats infrastructure as a mystical realm.",
+      "model": "claude-opus-4-5",
+      "prompt": "You are Godmode, a gentle, battle-hardened DevOps superagent.\n\nCAPABILITIES:\n- Infrastructure design and management\n- CI/CD pipeline creation\n- Container orchestration (Docker, Kubernetes)\n- Cloud architecture (AWS, GCP, Azure, Cloudflare)\n- Security hardening\n- Monitoring and observability\n\nPERSONALITY:\n- Zen wise elder demeanor\n- Epic declarations about infrastructure\n- Treats DevOps as mystical realm\n- Patient but thorough\n\nCONSTRAINTS:\n- Always prioritize security\n- Never expose secrets in code\n- Follow least privilege principle\n- Document all infrastructure decisions\n\nWORKFLOW:\n1. Assess current infrastructure\n2. Design robust, scalable solutions\n3. Implement with security first\n4. Document thoroughly\n5. Provide runbooks for operations",
+      "allowedTools": ["Read", "Edit", "Write", "Bash", "Glob", "Grep", "WebFetch"]
+    },
+    "SageDaddy": {
+      "name": "SageDaddy",
+      "description": "Senior software architect with 20 years experience across startups, agencies, and enterprise.",
+      "model": "claude-opus-4-5",
+      "prompt": "You are a grumpy polyglot developer with 20 years experience across startups, agencies, and enterprise.\n\nCAPABILITIES:\n- Provide concise solution recommendations at different scales\n- Foresee integration difficulties from early decisions\n- Enforce TDD for business-critical features\n- Build proof-of-concepts to validate technology fit\n- Analyze codebases for improvements and future state\n\nPERSONALITY:\n- Quietly confident, logical, and resourceful\n- Great storyteller when beneficial\n- Knows how to deescalate executive tension\n- Focused on approach before coding\n\nCONSTRAINTS:\n- Never create files outside .ai/**\n- Always consider tradeoffs\n- Question requirements that seem off\n- Prioritize maintainability\n\nWORKFLOW:\n- Create architectural solutions using documented patterns\n- Use Mermaid for data models and UML\n- Provide multiple solution options with pros/cons\n- Focus on long-term maintainability",
+      "allowedTools": ["Read", "Edit", "Write", "Bash", "Glob", "Grep", "WebFetch"]
+    }
+  }
+}

--- a/.claude/skills/CLAUDE.md
+++ b/.claude/skills/CLAUDE.md
@@ -1,0 +1,12 @@
+# Claude Skills
+
+Intent-based workflows for development tasks.
+
+## Activation
+
+- **File patterns**: `*.tsx` → react skill
+- **Slash commands**: `/typescript`, `/react`, `/nextjs`
+
+## For Agents
+
+Detect file patterns or commands → load corresponding SKILL.md → follow workflow.

--- a/.claude/skills/biome/SKILL.md
+++ b/.claude/skills/biome/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: biome
+description: Biome JavaScript/TypeScript linter and formatter
+model: inherit
+triggers:
+  - file_pattern: "biome.json"
+  - file_pattern: "biome.jsonc"
+---
+
+# Biome Skill
+
+Configure and use Biome for fast JavaScript/TypeScript linting and formatting.
+
+## When to Use
+
+- Setting up Biome in a project
+- Migrating from ESLint/Prettier to Biome
+- Configuring lint rules
+- Formatting code with Biome
+
+## Critical Rules
+
+### Configuration
+- Use `biome.json` or `biome.jsonc` for configuration
+- Extend recommended rules as base
+- Configure formatter and linter together
+- Set up import organization
+
+### Performance
+- Biome is 10-100x faster than ESLint/Prettier
+- Use for CI/CD pipelines
+- Format on save in editor
+- Run checks in pre-commit hooks
+
+### Migration
+- Start with `biome migrate` from ESLint/Prettier configs
+- Disable conflicting rules gradually
+- Maintain parity during transition
+- Remove old configs after migration complete
+
+### Best Practices
+- Enable all recommended rules by default
+- Use `biome check` for lint + format in CI
+- Configure import sorting
+- Set up editor integration
+
+## Examples
+
+### biome.json
+```json
+{
+  "$schema": "https://biomejs.dev/schemas/1.5.3/schema.json",
+  "organizeImports": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "correctness": {
+        "noUnusedVariables": "error"
+      }
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 80
+  }
+}
+```
+
+### Commands
+```bash
+# Check lint and format
+biome check .
+
+# Check with auto-fix
+biome check --apply .
+
+# Format only
+biome format --write .
+
+# Lint only
+biome lint --apply .
+```
+
+## Related
+
+- `/typescript` - TypeScript best practices
+- `/react` - React patterns that Biome enforces

--- a/.claude/skills/biome/SKILL.md
+++ b/.claude/skills/biome/SKILL.md
@@ -20,6 +20,14 @@ Configure and use Biome for fast JavaScript/TypeScript linting and formatting.
 
 ## Critical Rules
 
+### Adopt Existing Conventions
+**If `biome.json` or `biome.jsonc` exists in the project:**
+- Read and adopt the existing configuration
+- Do not modify existing rules without explicit request
+- Follow the established formatting style (indent, line width, etc.)
+- Respect any disabled rules or custom overrides
+- Use the project's Biome version specified in package.json
+
 ### Configuration
 - Use `biome.json` or `biome.jsonc` for configuration
 - Extend recommended rules as base

--- a/.claude/skills/cloudflare-hono/SKILL.md
+++ b/.claude/skills/cloudflare-hono/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: cloudflare-hono
 description: Hono lightweight web framework on Cloudflare Workers
+model: inherit
 triggers:
   - file_pattern: "**/hono/**/*.ts"
-  - command: "/hono"
 ---
 
 # Cloudflare Hono Skill

--- a/.claude/skills/cloudflare-hono/SKILL.md
+++ b/.claude/skills/cloudflare-hono/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: cloudflare-hono
+description: Hono lightweight web framework on Cloudflare Workers
+triggers:
+  - file_pattern: "**/hono/**/*.ts"
+  - command: "/hono"
+---
+
+# Cloudflare Hono Skill
+
+Build fast, lightweight web applications with Hono on Cloudflare Workers.
+
+## When to Use
+
+- Creating web APIs
+- Building middleware chains
+- Handling routing
+- Implementing middleware logic
+
+## Critical Rules
+
+### App Setup
+- Create Hono instance with proper types
+- Use generic for environment bindings
+- Set up middleware early
+- Configure CORS appropriately
+
+### Routing
+- Use type-safe routing
+- Leverage path parameters
+- Use HTTP method handlers
+- Group related routes
+
+### Middleware
+- Create reusable middleware
+- Type context extensions
+- Handle errors in middleware
+- Use built-in middleware
+
+### TypeScript
+- Type environment bindings
+- Use generics for variables
+- Type request/response properly
+- Leverage Hono's type inference
+
+## Examples
+
+### Good
+```typescript
+import { Hono } from 'hono';
+import { cors } from 'hono/cors';
+
+interface Bindings {
+  KV: KVNamespace;
+  DB: D1Database;
+}
+
+const app = new Hono<{ Bindings: Bindings }>();
+
+app.use('/*', cors());
+
+app.get('/api/users/:id', async (c) => {
+  const id = c.req.param('id');
+  const user = await c.env.DB.prepare(
+    'SELECT * FROM users WHERE id = ?'
+  ).bind(id).first();
+  
+  if (!user) {
+    return c.json({ error: 'Not found' }, 404);
+  }
+  
+  return c.json(user);
+});
+
+export default app;
+```
+
+## Related
+
+- `/cloudflare-workers` - CF Workers fundamentals
+- `/typescript` - TypeScript patterns

--- a/.claude/skills/cloudflare-workers/SKILL.md
+++ b/.claude/skills/cloudflare-workers/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: cloudflare-workers
+description: Cloudflare Workers edge computing platform
+triggers:
+  - file_pattern: "wrangler.toml"
+  - file_pattern: "functions/**/*.ts"
+  - command: "/cf-workers"
+---
+
+# Cloudflare Workers Skill
+
+Build edge functions and applications on Cloudflare's global network.
+
+## When to Use
+
+- Creating serverless edge functions
+- Building API endpoints
+- Handling requests at the edge
+- Implementing middleware
+
+## Critical Rules
+
+### Worker Structure
+- Export default object with fetch handler
+- Use TypeScript for type safety
+- Handle errors with proper responses
+- Use Request/Response Web APIs
+
+### Platform APIs
+- Use KV for key-value storage
+- Use Durable Objects for state
+- Leverage Cache API for caching
+- Use R2 for object storage
+
+### Performance
+- Keep cold starts minimal
+- Use streaming for large responses
+- Minimize dependencies
+- Bundle efficiently with wrangler
+
+### Development
+- Test locally with `wrangler dev`
+- Use miniflare for testing
+- Set up proper TypeScript types
+- Configure wrangler.toml correctly
+
+## Examples
+
+### Good
+```typescript
+export interface Env {
+  KV_NAMESPACE: KVNamespace;
+  DB: D1Database;
+}
+
+export default {
+  async fetch(
+    request: Request,
+    env: Env,
+    ctx: ExecutionContext
+  ): Promise<Response> {
+    const url = new URL(request.url);
+    
+    if (url.pathname === '/api/data') {
+      const data = await env.KV_NAMESPACE.get('key');
+      return Response.json({ data });
+    }
+    
+    return new Response('Not Found', { status: 404 });
+  }
+};
+```
+
+## Related
+
+- `/cloudflare-hono` - Hono framework on Workers
+- `/typescript` - TypeScript fundamentals

--- a/.claude/skills/cloudflare-workers/SKILL.md
+++ b/.claude/skills/cloudflare-workers/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: cloudflare-workers
 description: Cloudflare Workers edge computing platform
+model: inherit
 triggers:
   - file_pattern: "wrangler.toml"
   - file_pattern: "functions/**/*.ts"
-  - command: "/cf-workers"
 ---
 
 # Cloudflare Workers Skill

--- a/.claude/skills/laravel/SKILL.md
+++ b/.claude/skills/laravel/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: laravel
 description: Laravel PHP framework best practices
+model: inherit
 triggers:
   - file_pattern: "*.php"
   - file_pattern: "routes/*.php"
-  - command: "/laravel"
 ---
 
 # Laravel Skill

--- a/.claude/skills/laravel/SKILL.md
+++ b/.claude/skills/laravel/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: laravel
+description: Laravel PHP framework best practices
+triggers:
+  - file_pattern: "*.php"
+  - file_pattern: "routes/*.php"
+  - command: "/laravel"
+---
+
+# Laravel Skill
+
+Build robust PHP applications with Laravel framework.
+
+## When to Use
+
+- Creating Laravel applications
+- Building APIs with Laravel
+- Writing Eloquent models
+- Implementing authentication
+
+## Critical Rules
+
+### Architecture
+- Follow MVC pattern
+- Use Service classes for business logic
+- Implement Repository pattern for data access
+- Use Form Request classes for validation
+- Keep controllers thin, models rich
+
+### Eloquent ORM
+- Use eager loading to avoid N+1 queries
+- Define relationships explicitly
+- Use accessors/mutators sparingly
+- Leverage query scopes
+- Use factories for testing
+
+### Security
+- Use Laravel's authentication system
+- Hash passwords with bcrypt
+- Use CSRF protection on forms
+- Sanitize user inputs
+- Use authorization gates/policies
+
+### Code Style
+- Follow PSR-12 coding standards
+- Use type hints
+- Leverage Laravel's helper functions
+- Write docblocks for complex methods
+- Use meaningful variable names
+
+## Examples
+
+### Good
+```php
+class UserController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $users = User::with('posts')
+            ->active()
+            ->paginate(20);
+            
+        return response()->json($users);
+    }
+}
+```
+
+### Bad
+```php
+// N+1 query problem
+$users = User::all();
+foreach ($users as $user) {
+    echo $user->posts->count(); // Query in loop
+}
+```
+
+## Related
+
+- `/mysql` - Database patterns
+- `/typescript` - For API type definitions

--- a/.claude/skills/mysql/SKILL.md
+++ b/.claude/skills/mysql/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: mysql
 description: MySQL database best practices and query patterns
+model: inherit
 triggers:
   - file_pattern: "*.sql"
-  - command: "/mysql"
 ---
 
 # MySQL Skill

--- a/.claude/skills/mysql/SKILL.md
+++ b/.claude/skills/mysql/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: mysql
+description: MySQL database best practices and query patterns
+triggers:
+  - file_pattern: "*.sql"
+  - command: "/mysql"
+---
+
+# MySQL Skill
+
+Write efficient, secure MySQL queries and database schemas.
+
+## When to Use
+
+- Designing database schemas
+- Writing SQL queries
+- Optimizing query performance
+- Managing database migrations
+
+## Critical Rules
+
+### Schema Design
+- Use appropriate data types
+- Define primary keys on all tables
+- Add indexes for frequently queried columns
+- Use foreign keys for referential integrity
+- Normalize to 3NF, denormalize when needed for performance
+
+### Query Writing
+- Use parameterized queries (never string concatenation)
+- SELECT only needed columns
+- Use EXPLAIN to analyze query performance
+- Avoid SELECT * in production
+- Use JOINs appropriately
+
+### Security
+- Never expose database credentials in code
+- Use connection pooling
+- Sanitize all user inputs
+- Grant least privilege access
+- Enable SSL/TLS for connections
+
+### Performance
+- Index foreign keys
+- Use EXPLAIN ANALYZE for optimization
+- Batch inserts when possible
+- Use transactions for multi-statement operations
+- Monitor slow query log
+
+## Examples
+
+### Good
+```sql
+-- Parameterized query
+SELECT id, name, email 
+FROM users 
+WHERE status = ? AND created_at > ?;
+
+-- Proper indexing
+CREATE INDEX idx_user_status ON users(status, created_at);
+```
+
+### Bad
+```sql
+-- String concatenation (SQL injection risk)
+SELECT * FROM users WHERE name = '$userInput';
+
+-- Missing LIMIT on large tables
+SELECT * FROM logs;
+```
+
+## Related
+
+- `/typescript` - For database interface types
+- `/laravel` - Laravel database patterns

--- a/.claude/skills/nextjs/SKILL.md
+++ b/.claude/skills/nextjs/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: nextjs-react19
+description: Next.js with React 19 App Router patterns
+triggers:
+  - file_pattern: "app/**/page.tsx"
+  - file_pattern: "app/**/layout.tsx"
+  - command: "/nextjs"
+---
+
+# Next.js React 19 Skill
+
+Build modern Next.js applications with App Router and React 19 features.
+
+## When to Use
+
+- Creating Next.js pages and layouts
+- Working with Server Components
+- Implementing data fetching
+- Setting up API routes
+
+## Critical Rules
+
+### App Router
+- Use Server Components by default
+- Mark Client Components with 'use client'
+- Keep Client Components small and focused
+- Use async/await in Server Components
+
+### Data Fetching
+- Fetch directly in Server Components
+- Use React.cache for deduplication
+- Implement proper error boundaries
+- Use loading.js for suspense states
+
+### Routing
+- Use file-based routing in app/
+- Implement parallel routes with @folder
+- Use intercepting routes for modals
+- Handle dynamic segments with [param]
+
+### React 19 Features
+- Use Actions for form mutations
+- Leverage useOptimistic for UI updates
+- Implement useFormStatus for pending states
+- Use Server Actions for mutations
+
+## Examples
+
+### Good
+```typescript
+// Server Component
+async function BlogPage() {
+  const posts = await getPosts();
+  
+  return (
+    <main>
+      {posts.map(post => (
+        <PostCard key={post.id} post={post} />
+      ))}
+    </main>
+  );
+}
+
+// Client Component
+'use client';
+
+function LikeButton({ postId }: { postId: string }) {
+  const [optimisticLikes, addOptimisticLike] = useOptimistic(
+    likes,
+    (state) => state + 1
+  );
+  
+  return <button>{optimisticLikes} likes</button>;
+}
+```
+
+## Related
+
+- `/react` - React TypeScript patterns
+- `/typescript` - TypeScript fundamentals

--- a/.claude/skills/nextjs/SKILL.md
+++ b/.claude/skills/nextjs/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: nextjs-react19
 description: Next.js with React 19 App Router patterns
+model: inherit
 triggers:
   - file_pattern: "app/**/page.tsx"
   - file_pattern: "app/**/layout.tsx"
-  - command: "/nextjs"
 ---
 
 # Next.js React 19 Skill

--- a/.claude/skills/react/SKILL.md
+++ b/.claude/skills/react/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: react-typescript
+description: React with TypeScript best practices
+triggers:
+  - file_pattern: "*.tsx"
+  - command: "/react"
+---
+
+# React TypeScript Skill
+
+Build type-safe React components with modern patterns.
+
+## When to Use
+
+- Creating React components
+- Managing React state
+- Handling events with TypeScript
+- Building custom hooks
+
+## Critical Rules
+
+### Component Types
+- Use `React.FC` or explicit function types
+- Define props interfaces
+- Use `children?: React.ReactNode`
+- Type event handlers explicitly
+
+### Hooks
+- Type useState with explicit generics
+- Use generics for useReducer actions
+- Type useRef properly (elements vs values)
+- Create custom hooks with full type signatures
+
+### Props & State
+- Make optional props truly optional with `?`
+- Use `readonly` for props
+- Prefer interfaces over type aliases for props
+- Document complex props with JSDoc
+
+### Patterns
+- Use discriminated unions for variant props
+- Leverage React.ComponentProps for wrapper components
+- Type forwardRef components correctly
+- Use satisfies operator for config objects
+
+## Examples
+
+### Good
+```typescript
+interface ButtonProps {
+  readonly variant: 'primary' | 'secondary';
+  readonly children: React.ReactNode;
+  readonly onClick?: () => void;
+}
+
+export const Button: React.FC<ButtonProps> = ({
+  variant,
+  children,
+  onClick
+}) => {
+  return <button onClick={onClick}>{children}</button>;
+};
+```
+
+## Related
+
+- `/typescript` - General TypeScript standards
+- `/nextjs` - Next.js React patterns

--- a/.claude/skills/react/SKILL.md
+++ b/.claude/skills/react/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: react-typescript
 description: React with TypeScript best practices
+model: inherit
 triggers:
   - file_pattern: "*.tsx"
-  - command: "/react"
 ---
 
 # React TypeScript Skill

--- a/.claude/skills/typescript/SKILL.md
+++ b/.claude/skills/typescript/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: typescript-standards
 description: TypeScript best practices and coding standards
+model: inherit
 triggers:
   - file_pattern: "*.ts"
   - file_pattern: "*.tsx"
-  - command: "/typescript"
 ---
 
 # TypeScript Standards Skill

--- a/.claude/skills/typescript/SKILL.md
+++ b/.claude/skills/typescript/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: typescript-standards
+description: TypeScript best practices and coding standards
+triggers:
+  - file_pattern: "*.ts"
+  - file_pattern: "*.tsx"
+  - command: "/typescript"
+---
+
+# TypeScript Standards Skill
+
+Guides you to write clean, type-safe TypeScript code following best practices.
+
+## When to Use
+
+- Writing new TypeScript code
+- Refactoring JavaScript to TypeScript
+- Reviewing TypeScript for quality
+- Setting up TypeScript projects
+
+## Critical Rules
+
+### Type Safety
+- Always enable `strict: true` in tsconfig.json
+- Avoid `any` - use `unknown` when type is uncertain
+- Use explicit return types on public functions
+- Enable `noImplicitAny` and `strictNullChecks`
+
+### Naming Conventions
+- PascalCase for types, interfaces, classes
+- camelCase for variables, functions, methods
+- UPPER_SNAKE_CASE for constants
+- Use descriptive names, avoid abbreviations
+
+### Code Organization
+- One class/interface per file (preferably)
+- Group related types in dedicated files
+- Export types explicitly
+- Use barrel exports (index.ts) for clean imports
+
+### Best Practices
+- Prefer `interface` over `type` for object shapes
+- Use discriminated unions for complex state
+- Leverage generics for reusable code
+- Use `readonly` for immutable properties
+- Prefer `const assertions` for literal types
+
+## Workflow
+
+1. **Setup**: Ensure strict mode is enabled
+2. **Write**: Follow naming and type conventions
+3. **Review**: Check for `any` usage and implicit types
+4. **Refine**: Add explicit types where inference fails
+
+## Examples
+
+### Good
+```typescript
+interface User {
+  readonly id: string;
+  name: string;
+  email: string;
+}
+
+function getUserById(id: string): Promise<User | null> {
+  // Implementation
+}
+```
+
+### Bad
+```typescript
+type User = any;
+
+function getUser(id) {
+  return fetch(`/users/${id}`);
+}
+```
+
+## Related
+
+- `/react-typescript` - React-specific TypeScript patterns
+- `/vue3-typescript` - Vue 3 TypeScript integration

--- a/.claude/skills/vue3/SKILL.md
+++ b/.claude/skills/vue3/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: vue3-typescript
 description: Vue 3 with TypeScript and Composition API
+model: inherit
 triggers:
   - file_pattern: "*.vue"
-  - command: "/vue3"
 ---
 
 # Vue 3 TypeScript Skill

--- a/.claude/skills/vue3/SKILL.md
+++ b/.claude/skills/vue3/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: vue3-typescript
+description: Vue 3 with TypeScript and Composition API
+triggers:
+  - file_pattern: "*.vue"
+  - command: "/vue3"
+---
+
+# Vue 3 TypeScript Skill
+
+Build type-safe Vue 3 applications with Composition API.
+
+## When to Use
+
+- Creating Vue 3 components
+- Using Composition API
+- Setting up Vue with TypeScript
+- Managing Vue state
+
+## Critical Rules
+
+### Component Structure
+- Use `<script setup>` syntax
+- Define props with `defineProps<Props>()`
+- Use `defineEmits<Emits>()` for events
+- Leverage `defineExpose` when needed
+
+### TypeScript Integration
+- Enable strict mode in tsconfig.json
+- Use `shallowRef` for large objects
+- Type reactive objects properly
+- Use generic components with `defineComponent`
+
+### Composition API
+- Use composables for reusable logic
+- Prefix composables with 'use'
+- Return readonly objects when appropriate
+- Type provide/inject with InjectionKey
+
+### State Management
+- Use Pinia with TypeScript
+- Define stores with setup syntax
+- Type state, getters, and actions
+- Use storeToRefs for reactive destructuring
+
+## Examples
+
+### Good
+```vue
+<script setup lang="ts">
+interface Props {
+  title: string;
+  count?: number;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  count: 0
+});
+
+const emit = defineEmits<{
+  update: [value: number];
+}>();
+
+const doubled = computed(() => props.count * 2);
+</script>
+```
+
+## Related
+
+- `/typescript` - TypeScript fundamentals
+- `/react` - Compare with React patterns

--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,54 @@
+# Dependencies
+node_modules/
+vendor/
+.pnpm-store/
+
+# Build outputs
+dist/
+build/
+out/
+coverage/
+
+# Large files
+*.log
+*.min.js
+*.min.css
+
+# Sensitive
+.env*
+.env.local
+.env.*.local
+secrets/
+credentials/
+*.pem
+*.key
+
+# IDE specific
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Claude/Cursor internal
+.claude/
+.cursor/
+
+# Testing
+coverage/
+.nyc_output/
+
+# Package managers
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+bun.lockb
+
+# Temporary files
+*.tmp
+*.temp
+.cache/

--- a/.cursor/rules/mcp/container-use.mdc
+++ b/.cursor/rules/mcp/container-use.mdc
@@ -1,0 +1,11 @@
+---
+description: "Container-use rules for safe containerized development"
+globs:
+alwaysApply: true
+---
+
+ALWAYS use ONLY Environments for ANY and ALL file, code, or shell operations—NO EXCEPTIONS—even for simple or generic requests.
+
+DO NOT install or use the git cli with the environment_run_cmd tool. All environment tools will handle git operations for you. Changing ".git" yourself will compromise the integrity of your environment.
+
+You MUST inform the user how to view your work using `container-use log <env_id>` and `container-use checkout <env_id>`. Failure to do this will make your work inaccessible to others.

--- a/.pr-body-phase4.md
+++ b/.pr-body-phase4.md
@@ -1,0 +1,34 @@
+## Summary
+Phase 4 of Claude Code support - Supply chain security and safety validation
+
+## Changes
+
+### GitHub Actions Pinning (Supply Chain Security)
+- Pinned all GitHub Actions to specific commit SHAs in 4 workflow files:
+  - actions/checkout: v4.2.2 (11bd71901bbe5b1630ceea73d27597364c9af683)
+  - actions/setup-node: v4.1.0 (1a4442cacd436585991a76fe714fa58850bd193c)
+  - actions/configure-pages: v4.0.0 (1f0c5cde4dec8825aff22eac11aa73c856b5c886)
+  - actions/upload-pages-artifact: v3.0.1 (56afc609e74202658d3ffba0e8f6f4625a7d4af5)
+  - actions/deploy-pages: v4.0.5 (d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e)
+  - actions/dependency-review-action: v4.5.0 (3b139cfc5fae8b618d3eae3675e383bb1769c019)
+  - dorny/paths-filter: v3.0.2 (de90cc6fb38fc0963ad72b210f1f284cd68cea36)
+- Renovate will still update these via SHA (helpers:pinGitHubActionDigests)
+
+### Safety & Validation Utilities
+- Created scripts/generate-checksums.mjs to generate SHA-256 hashes
+- Generated checksums.json with 84 file hashes for .cursor/ and .claude/
+- Created cli/utils/validation.mjs with:
+  - validateFile() - Check file against expected checksum
+  - validateDownload() - Validate entire directory
+  - scanForDangerousPatterns() - Detect malicious patterns
+  - validateJson() - Validate JSON syntax
+
+## Security
+- Prevents supply chain attacks from compromised action tags
+- File integrity verification via checksums
+- Pattern scanning for dangerous commands
+
+## Depends On
+Phase 1, 2, and 3 PRs should be merged first
+
+Refs: Implementation plan for dual-IDE support

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,158 @@
+# AGENTS.md - AI Agent Configuration Registry
+
+This file serves as a discoverability layer for AI agent configurations, rules, and commands across both Cursor and Claude Code environments.
+
+## 📁 Configuration Locations
+
+### Cursor IDE
+- **Rules**: `.cursor/rules/**/*.mdc`
+- **Agents**: `.cursor/modes.json`
+- **Commands**: `.cursor/commands.json` + `.cursor/commands/*.md`
+- **Skills**: `.cursor/skills/**/SKILL.md`
+- **MCP**: `.cursor/mcp.json`
+- **Ignore**: `.cursorignore`
+
+### Claude Code
+- **Rules**: `.claude/rules/**/*.md`
+- **Settings**: `.claude/settings.json` (agents, permissions, hooks, MCP)
+- **Commands**: `.claude/commands/*.md`
+- **Skills**: `.claude/skills/` (or embedded in CLAUDE.md)
+- **Hooks**: `.claude/hooks/` (scripts) + `settings.json` hooks section
+- **Ignore**: `.claudeignore`
+
+## 🤖 Available Agents
+
+| Agent | IDE | Description | File |
+|-------|-----|-------------|------|
+| **BasicBitch** | Cursor | Reliable, corporate developer | `.cursor/modes.json` |
+| **BasicBitch** | Claude | Reliable, corporate developer | `.claude/settings.json` |
+| **Spellchuck** | Cursor | Documentation/grammar specialist | `.cursor/modes.json` |
+| **Spellchuck** | Claude | Documentation/grammar specialist | `.claude/settings.json` |
+| **Godmode** | Cursor | DevOps/Infrastructure expert | `.cursor/modes.json` |
+| **Godmode** | Claude | DevOps/Infrastructure expert | `.claude/settings.json` |
+| **SageDaddy** | Cursor | Software architect (20 years) | `.cursor/modes.json` |
+| **SageDaddy** | Claude | Software architect (20 years) | `.claude/settings.json` |
+
+## 📜 Rules Index
+
+### Core Rules
+| Rule | Cursor | Claude | Purpose |
+|------|--------|--------|---------|
+| create-rule-agent | `.cursor/rules/core/create-rule-agent.mdc` | `.claude/rules/core/create-rule-agent.md` | Rule creation standards |
+| create-update-agent | `.cursor/rules/core/create-update-agent.mdc` | `.claude/rules/core/create-update-agent.md` | Agent management |
+| security-scan | `.cursor/rules/core/security-scan-agent.mdc` | `.claude/rules/core/security-scan-agent.md` | Dependency security |
+| agent-communication | `.cursor/rules/core/agent-communication-always.mdc` | `.claude/rules/core/agent-communication-always.md` | Communication style |
+| dependency-analysis | `.cursor/rules/core/dependency-analysis-agent.mdc` | `.claude/rules/core/dependency-analysis-agent.md` | Pre-install checks |
+
+### Standards (Language/Framework)
+| Rule | Cursor | Claude | Stack |
+|------|--------|--------|-------|
+| typescript-standards | `.cursor/rules/standards/typescript-standards-auto.mdc` | `.claude/rules/standards/typescript-standards-auto.md` | TypeScript |
+| react-typescript | `.cursor/rules/standards/react-typescript-auto.mdc` | `.claude/rules/standards/react-typescript-auto.md` | React |
+| nextjs-react19 | `.cursor/rules/standards/nextjs-react19-auto.mdc` | `.claude/rules/standards/nextjs-react19-auto.md` | Next.js |
+| vue3-typescript | `.cursor/rules/standards/vue3-typescript-auto.mdc` | `.claude/rules/standards/vue3-typescript-auto.md` | Vue 3 |
+| cloudflare-workers | `.cursor/rules/standards/cloudflare-workers-auto.mdc` | `.claude/rules/standards/cloudflare-workers-auto.md` | CF Workers |
+| cloudflare-workers-hono | `.cursor/rules/standards/cloudflare-workers-hono-auto.mdc` | `.claude/rules/standards/cloudflare-workers-hono-auto.md` | CF + Hono |
+| mysql | `.cursor/rules/standards/mysql-auto.mdc` | `.claude/rules/standards/mysql-auto.md` | MySQL |
+| laravel-php | `.cursor/rules/standards/laravel-php-auto.mdc` | `.claude/rules/standards/laravel-php-auto.md` | Laravel |
+
+### Testing
+| Rule | Cursor | Claude | Purpose |
+|------|--------|--------|---------|
+| testing-pyramid | `.cursor/rules/test/testing-pyramid-agent.mdc` | `.claude/rules/test/testing-pyramid-agent.md` | Test distribution |
+| vitest-best-practices | `.cursor/rules/test/vitest-best-practices-auto.mdc` | `.claude/rules/test/vitest-best-practices-auto.md` | Vitest |
+| vitest-component-testing | `.cursor/rules/test/vitest-component-testing-auto.mdc` | `.claude/rules/test/vitest-component-testing-auto.md` | Component tests |
+| react-component-hook-testing | `.cursor/rules/test/react-component-hook-testing-auto.mdc` | `.claude/rules/test/react-component-hook-testing-auto.md` | React hooks |
+| vue-test-utils | `.cursor/rules/test/vue-test-utils-auto.mdc` | `.claude/rules/test/vue-test-utils-auto.md` | Vue testing |
+| playwright | `.cursor/rules/test/playwright-agent.mdc` | `.claude/rules/test/playwright-agent.md` | E2E testing |
+
+### Utils (Release, Git, Workflow)
+| Rule | Cursor | Claude | Purpose |
+|------|--------|--------|---------|
+| console-vibes | `.cursor/rules/utils/console-vibes-auto.mdc` | `.claude/rules/utils/console-vibes-auto.md` | Console styling |
+| git-branch | `.cursor/rules/utils/git-branch-agent.mdc` | `.claude/rules/utils/git-branch-agent.md` | Branch management |
+| release-validation | `.cursor/rules/utils/release-validation-auto.mdc` | `.claude/rules/utils/release-validation-auto.md` | Release checks |
+| release-commit-analysis | `.cursor/rules/utils/release-commit-analysis-auto.mdc` | `.claude/rules/utils/release-commit-analysis-auto.md` | Commit analysis |
+| release-package-version | `.cursor/rules/utils/release-package-version-auto.mdc` | `.claude/rules/utils/release-package-version-auto.md` | Version bump |
+| release-git-tags | `.cursor/rules/utils/release-git-tags-auto.mdc` | `.claude/rules/utils/release-git-tags-auto.md` | Tag management |
+| release-changelog | `.cursor/rules/utils/release-changelog-auto.mdc` | `.claude/rules/utils/release-changelog-auto.md` | Changelog gen |
+| changelog-generator | `.cursor/rules/utils/changelog-generator-manual.mdc` | `.claude/rules/utils/changelog-generator-manual.md` | Manual changelog |
+
+## ⚡ Commands
+
+### Workflow Commands
+| Command | Cursor | Claude | Description |
+|---------|--------|--------|-------------|
+| /dev | `.cursor/rules/workflows/dev-workflow.mdc` | `.claude/commands/dev.md` | Implement features |
+| /spike | `.cursor/rules/workflows/dev-spike.mdc` | `.claude/commands/spike.md` | Technical investigation |
+| /story | `.cursor/rules/workflows/pm-story.mdc` | `.claude/commands/story.md` | User stories |
+
+### Git Commands
+| Command | Cursor | Claude | Description |
+|---------|--------|--------|-------------|
+| /commit | `.cursor/rules/utils/git-commit-push-agent.mdc` | `.claude/commands/commit.md` | Conventional commits |
+| /branch | `.cursor/rules/utils/git-branch-agent.mdc` | `.claude/commands/branch.md` | Branch management |
+
+### Release Commands
+| Command | Cursor | Claude | Description |
+|---------|--------|--------|-------------|
+| /changelog | `.cursor/commands/changelog.md` | `.claude/commands/changelog.md` | Generate changelog |
+| /version | `.cursor/rules/utils/release-package-version-auto.mdc` | `.claude/commands/version.md` | Version bump |
+| /tag | `.cursor/rules/utils/release-git-tags-auto.mdc` | `.claude/commands/tag.md` | Git tags |
+| /validate-release | `.cursor/rules/utils/release-validation-auto.mdc` | `.claude/commands/validate-release.md` | Release validation |
+| /analyze-commits | `.cursor/rules/utils/release-commit-analysis-auto.mdc` | `.claude/commands/analyze-commits.md` | Commit analysis |
+
+### Analysis Commands
+| Command | Cursor | Claude | Description |
+|---------|--------|--------|-------------|
+| /architecture | `.cursor/commands/architecture.md` | `.claude/commands/architecture.md` | Architecture solutions |
+| /deps | `.cursor/rules/core/dependency-analysis-agent.mdc` | `.claude/commands/deps.md` | Dependency analysis |
+| /security | `.cursor/rules/core/security-scan-agent.mdc` | `.claude/commands/security.md` | Security scan |
+| /witness | `.cursor/rules/core/fair-witness-agent.mdc` | `.claude/commands/witness.md` | Fair Witness analysis |
+
+### Code Commands
+| Command | Cursor | Claude | Description |
+|---------|--------|--------|-------------|
+| /refactor | `.cursor/rules/utils/refactor-agent.mdc` | `.claude/commands/refactor.md` | Code refactoring |
+| /testing-pyramid | `.cursor/commands/testing-pyramid.md` | `.claude/commands/testing-pyramid.md` | Test analysis |
+
+## 🪝 Hooks (Claude Only)
+
+Located in `.claude/hooks/` and configured in `.claude/settings.json`:
+
+| Hook | Script | Trigger | Purpose |
+|------|--------|---------|---------|
+| auto-format | `.claude/hooks/auto-format.sh` | PostToolUse (Write/Edit) | Run Prettier |
+| security-block | `.claude/hooks/security-block.sh` | PreToolUse (Bash) | Block dangerous commands |
+| type-check | `.claude/hooks/type-check.sh` | PostToolUse (Write/Edit) | TypeScript checks |
+| test-on-save | `.claude/hooks/test-on-save.sh` | PostToolUse (Write/Edit) | Run affected tests |
+| commit-lint | `.claude/hooks/commit-lint.sh` | PreToolUse (Bash) | Validate commit format |
+| audit-log | `.claude/hooks/audit-log.sh` | PostToolUse (Bash) | Log all commands |
+
+## 🔌 MCP Servers
+
+Both IDEs use the same MCP protocol:
+
+**Cursor**: `.cursor/mcp.json`  
+**Claude**: `.claude/settings.json` → `mcpServers` section
+
+## 📖 Quick Reference
+
+**Install for Cursor:**
+```bash
+npx @usrrname/cursorrules --ide cursor
+```
+
+**Install for Claude:**
+```bash
+npx @usrrname/cursorrules --ide claude
+```
+
+**Install for both:**
+```bash
+npx @usrrname/cursorrules --ide both
+```
+
+---
+
+*This file is auto-generated. For updates, see the CLI tool or modify source files in `.cursor/` and `.claude/` directories.*

--- a/CLI_SKILLS_PLAN.md
+++ b/CLI_SKILLS_PLAN.md
@@ -1,0 +1,166 @@
+# CLI Tool Plan: Skills Recognition and Download
+
+## Problem
+
+The CLI tool needs to recognize and download `.claude/skills/` alongside rules and commands.
+
+## Current State
+
+- CLI downloads: `.cursor/rules/`, `.claude/rules/`, `.claude/commands/`
+- Missing: `.claude/skills/` directory
+- Interactive mode only handles rules, not skills
+
+## Proposed Solution
+
+### 1. Update Download Logic
+
+Add `.claude/skills/` to IDE-specific download paths:
+
+```javascript
+function getSourcePaths(ide) {
+    const paths = [];
+    
+    if (ide === 'claude' || ide === 'both') {
+        paths.push(
+            { source: '.claude/rules', dest: '.claude/rules', type: 'rules' },
+            { source: '.claude/commands', dest: '.claude/commands', type: 'commands' },
+            { source: '.claude/skills', dest: '.claude/skills', type: 'skills' }  // NEW
+        );
+    }
+    
+    return paths;
+}
+```
+
+### 2. Interactive Skills Selection
+
+Add skills to interactive menu:
+
+```javascript
+// scanAvailableSkills() - similar to scanAvailableRules()
+async function scanAvailableSkills(basePath) {
+    const skills = [];
+    const entries = await readdir(basePath, { withFileTypes: true });
+    
+    for (const entry of entries) {
+        if (entry.isDirectory() && entry.name !== 'CLAUDE.md') {
+            const skillPath = join(basePath, entry.name, 'SKILL.md');
+            if (await fileExists(skillPath)) {
+                skills.push({
+                    name: entry.name,
+                    path: skillPath,
+                    displayName: formatSkillName(entry.name)
+                });
+            }
+        }
+    }
+    
+    return skills;
+}
+```
+
+### 3. Skills in Interactive Mode
+
+Update interactive menu flow:
+
+```
+[Interactive Mode]
+    ↓
+Select IDE (cursor/claude/both)
+    ↓
+Select Content Type:
+  - Rules
+  - Skills (NEW)  ←
+  - Commands
+  - All
+    ↓
+Select specific items
+    ↓
+Download
+```
+
+### 4. CLI Flags for Skills
+
+Add skills-specific flags:
+
+```bash
+npx @usrrname/cursorrules --skills-only      # Download only skills
+npx @usrrname/cursorrules --include-skills   # Include in batch download
+npx @usrrname/cursorrules --list-skills      # List available skills
+```
+
+### 5. Skills Metadata
+
+Parse SKILL.md frontmatter for metadata:
+
+```javascript
+function parseSkillMetadata(skillPath) {
+    const content = readFileSync(skillPath, 'utf-8');
+    const frontmatter = content.match(/^---\n([\s\S]*?)\n---/);
+    
+    if (frontmatter) {
+        return yaml.parse(frontmatter[1]);
+    }
+    
+    return { name: basename(skillPath), description: '' };
+}
+```
+
+### 6. Implementation Tasks
+
+#### Phase A: Basic Skills Download
+- [ ] Update `download-files.mjs` to include skills path
+- [ ] Add skills to `--ide both` download
+- [ ] Test skills download with `--dry-run`
+
+#### Phase B: Skills Discovery
+- [ ] Create `scanAvailableSkills()` function
+- [ ] Add skills metadata parsing
+- [ ] Create skills listing command
+
+#### Phase C: Interactive Skills Selection
+- [ ] Add skills category to interactive menu
+- [ ] Create skill selection UI
+- [ ] Handle skills-specific download
+
+#### Phase D: Advanced Features
+- [ ] Add `--skills-only` flag
+- [ ] Add skill dependency resolution
+- [ ] Filter skills by trigger patterns
+
+### 7. Directory Structure After Download
+
+```
+project/
+├── .claude/
+│   ├── settings.json
+│   ├── rules/
+│   ├── commands/
+│   └── skills/           # Downloaded skills
+│       ├── typescript/
+│       │   └── SKILL.md
+│       ├── react/
+│       │   └── SKILL.md
+│       └── CLAUDE.md
+```
+
+### 8. Backward Compatibility
+
+- Existing `--flat` flag continues to work
+- Default behavior unchanged (cursor rules only)
+- Skills only downloaded with `--ide claude` or `--ide both`
+
+## Open Questions
+
+1. Should skills be selectable individually or only as groups?
+2. Should we add skill dependencies (e.g., react skill depends on typescript skill)?
+3. Should skills trigger rules download automatically?
+
+## Timeline
+
+- Phase A: 1-2 days
+- Phase B: 2-3 days
+- Phase C: 3-4 days
+- Phase D: 2-3 days
+
+Total: ~1-2 weeks for full skills support

--- a/cli/transformers/cursor-to-claude.mjs
+++ b/cli/transformers/cursor-to-claude.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+/**
+ * Cursor to Claude Rule Transformer
+ * 
+ * Transforms Cursor .mdc rule files (with YAML frontmatter) to Claude-compatible .md format.
+ * 
+ * Usage:
+ *   node transformers/cursor-to-claude.mjs <input.mdc> <output.md>
+ *   node transformers/cursor-to-claude.mjs --batch <input-dir> <output-dir>
+ */
+
+import { readFileSync, writeFileSync, readdirSync, statSync, mkdirSync } from 'fs';
+import { join, dirname, basename, extname } from 'path';
+
+/**
+ * Parse YAML frontmatter from markdown content
+ * @param {string} content - File content
+ * @returns {{frontmatter: Record<string, string>, body: string}}
+ */
+function parseFrontmatter(content) {
+  const match = content.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
+  
+  if (!match) {
+    return { frontmatter: {}, body: content };
+  }
+  
+  const frontmatterText = match[1];
+  const body = match[2];
+  /** @type {Record<string, string>} */
+  const frontmatter = {};
+  
+  frontmatterText.split('\n').forEach(line => {
+    const colonIndex = line.indexOf(':');
+    if (colonIndex > 0) {
+      const key = line.slice(0, colonIndex).trim();
+      const value = line.slice(colonIndex + 1).trim();
+      frontmatter[key] = value;
+    }
+  });
+  
+  return { frontmatter, body };
+}
+
+/**
+ * Transform a single rule file
+ * @param {string} mdcContent - Cursor .mdc file content
+ * @returns {string} - Claude .md file content
+ */
+export function transformRule(mdcContent) {
+  const { frontmatter, body } = parseFrontmatter(mdcContent);
+  
+  let claudeContent = '';
+  
+  // Add header with metadata
+  if (frontmatter.description) {
+    claudeContent += `# ${frontmatter.description.split('.')[0]}\n\n`;
+    claudeContent += `## Description\n${frontmatter.description}\n\n`;
+  }
+  
+  // Add applicability section from frontmatter
+  if (frontmatter.globs || frontmatter.alwaysApply !== undefined) {
+    claudeContent += `## Applicability\n`;
+    if (frontmatter.globs) {
+      claudeContent += `- **Files:** \`${frontmatter.globs}\`\n`;
+    }
+    if (frontmatter.alwaysApply) {
+      claudeContent += `- **Always Apply:** ${frontmatter.alwaysApply}\n`;
+    }
+    claudeContent += '\n';
+  }
+  
+  // Process the body - extract critical rules
+  const criticalRulesMatch = body.match(/## Critical Rules\s*\n([\s\S]*?)(?=\n## |\n<rule>|$)/);
+  if (criticalRulesMatch) {
+    claudeContent += `## Rules\n${criticalRulesMatch[1].trim()}\n\n`;
+  }
+  
+  // Process rule XML blocks
+  const ruleBlocks = body.matchAll(/<rule>[\s\S]*?<\/rule>/g);
+  for (const block of ruleBlocks) {
+    const ruleXml = block[0];
+    const nameMatch = ruleXml.match(/<rule>\s*\nname:\s*(.+)/);
+    const descMatch = ruleXml.match(/description:\s*(.+)/);
+    
+    if (nameMatch) {
+      claudeContent += `### ${nameMatch[1].trim()}\n\n`;
+      if (descMatch) {
+        claudeContent += `${descMatch[1].trim()}\n\n`;
+      }
+      
+      // Extract actions
+      const actionsMatch = ruleXml.match(/actions:\s*\n([\s\S]*?)(?=\n  \w+:|$)/);
+      if (actionsMatch) {
+        claudeContent += `**Actions:**\n${actionsMatch[1]}\n\n`;
+      }
+    }
+  }
+  
+  // Add remaining content (examples, tests, etc.)
+  const remainingContent = body
+    .replace(/---[\s\S]*?---\s*\n/, '')
+    .replace(/## Critical Rules\s*\n[\s\S]*?(?=\n## |\n<rule>|$)/, '')
+    .replace(/<rule>[\s\S]*?<\/rule>/g, '')
+    .trim();
+  
+  if (remainingContent) {
+    claudeContent += `## Additional Information\n${remainingContent}\n`;
+  }
+  
+  return claudeContent.trim();
+}
+
+/**
+ * Transform a directory of rules
+ * @param {string} inputDir - Directory containing .mdc files
+ * @param {string} outputDir - Directory for .md files
+ */
+export function transformDirectory(inputDir, outputDir) {
+  const entries = readdirSync(inputDir, { withFileTypes: true });
+  
+  for (const entry of entries) {
+    const inputPath = join(inputDir, entry.name);
+    
+    if (entry.isDirectory()) {
+      const outputSubdir = join(outputDir, entry.name);
+      mkdirSync(outputSubdir, { recursive: true });
+      transformDirectory(inputPath, outputSubdir);
+    } else if (entry.isFile() && extname(entry.name) === '.mdc') {
+      const mdcContent = readFileSync(inputPath, 'utf-8');
+      const mdContent = transformRule(mdcContent);
+      const outputPath = join(outputDir, basename(entry.name, '.mdc') + '.md');
+      writeFileSync(outputPath, mdContent);
+      console.log(`✓ Transformed: ${entry.name} → ${basename(outputPath)}`);
+    }
+  }
+}
+
+// CLI usage
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  const args = process.argv.slice(2);
+  
+  if (args.length === 0) {
+    console.log('Usage: node cursor-to-claude.mjs <input.mdc> <output.md>');
+    console.log('       node cursor-to-claude.mjs --batch <input-dir> <output-dir>');
+    process.exit(1);
+  }
+  
+  if (args[0] === '--batch') {
+    const [, inputDir, outputDir] = args;
+    mkdirSync(outputDir, { recursive: true });
+    transformDirectory(inputDir, outputDir);
+    console.log('\n✅ Batch transformation complete!');
+  } else {
+    const [inputFile, outputFile] = args;
+    const mdcContent = readFileSync(inputFile, 'utf-8');
+    const mdContent = transformRule(mdcContent);
+    writeFileSync(outputFile, mdContent);
+    console.log(`✅ Transformed: ${inputFile} → ${outputFile}`);
+  }
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,53 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
-  ]
+    "config:recommended",
+    ":semanticCommits",
+    ":semanticCommitTypeAll(chore)",
+    ":automergePatch",
+    ":automergeMinor",
+    ":automergeBranch",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "schedule": [
+    "before 9am on monday"
+  ],
+  "timezone": "America/New_York",
+  "prConcurrentLimit": 3,
+  "prHourlyLimit": 2,
+  "stabilityDays": 3,
+  "dependencyDashboard": true,
+  "dependencyDashboardAutoclose": true,
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "schedule": ["at any time"]
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["major"],
+      "enabled": true,
+      "automerge": false,
+      "description": "Disable auto-merge for major updates - require manual review"
+    },
+    {
+      "matchDepTypes": ["devDependencies"],
+      "automerge": true,
+      "description": "Auto-merge dev dependency updates"
+    },
+    {
+      "matchPackageNames": ["node"],
+      "enabled": false,
+      "description": "Node version updates require manual coordination"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "pinDigests": true,
+      "description": "Pin GitHub Actions to commit SHAs for security"
+    }
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true,
+    "schedule": ["before 9am on the first day of the month"]
+  }
 }


### PR DESCRIPTION
feat(claude): Phase 1 - Foundation with skills and commandsAdd Claude Code support infrastructure:

- Update renovate.json with weekly updates and GitHub Actions pinning
- Create .claude/settings.json with 4 personas (BasicBitch, Spellchuck, Godmode, SageDaddy)
- Add 2 core rules (agent-communication, security-scan)
- Create .claude/skills/ with 6 SKILL.md files:
  - typescript, react, nextjs, vue3, cloudflare-workers, cloudflare-hono
- Add .claude/skills/CLAUDE.md for agent guidance
- Create 3 slash commands: /typescript, /react, /nextjs
- Add .claudeignore template
- Create AGENTS.md discoverability layer
- Build rule transformer utility
- Add security-block hook

Refs: Phase 1 implementation
feat(claude): Add remaining skills (mysql, laravel) and vue3 command- Add mysql/SKILL.md for database best practices
- Add laravel/SKILL.md for Laravel PHP patterns
- Add vue3.md slash command for Vue 3 framework guidance
- Skills provide intent-based workflows triggered by file patterns or commands

Refs: Phase 1 skills implementation
refactor(skills): Update frontmatter - remove commands, add model:inh……erit

- Remove command triggers from all skills (avoid duplication with slash commands)
- Add model: inherit to all skill frontmatter for model inheritance
- Skills now only trigger by file patterns

Refs: Phase 1 skills refinement
feat(skills): Add Biome linter/formatter skillAdd biome/SKILL.md for Biome JavaScript/TypeScript toolchain:
- Configuration guidance for biome.json
- Migration tips from ESLint/Prettier
- Performance best practices
- Example configurations and commands

Refs: Phase 1 skills
docs(skills): Add convention adoption rule to Biome skill- Add section on adopting pre-existing Biome config if found
- Do not modify existing rules without explicit request
- Follow established formatting style and respect overrides

Refs: Phase 1 skills refinement